### PR TITLE
fix(session-detail): Add description conditional to prevent crash

### DIFF
--- a/src/app/schedule/session-detail.html
+++ b/src/app/schedule/session-detail.html
@@ -8,7 +8,7 @@
     </div>
     <div class="col-xs-12 col-sm-7">
       <h1>{{ session.title }}</h1>
-      <p style="white-space: pre-line" [innerHtml]="session.description | linkify"></p>
+      <p *ngIf="session.description" style="white-space: pre-line" [innerHtml]="session.description | linkify"></p>
       <p *ngIf="session.requiresComputer" class="computer-required">Notera att denna session kräver en dator</p>
     </div>
   </div>


### PR DESCRIPTION
Löser #2 genom att dölja description-paragrafen när den inte är satt.
