### PR TITLE
Update linkify.pipe.ts

### DIFF
--- a/src/app/common/linkify.pipe.ts
+++ b/src/app/common/linkify.pipe.ts
@@ -4,8 +4,11 @@ import {Pipe, PipeTransform} from 'angular2/core';
 export class LinkifyPipe implements PipeTransform {
   private pattern : RegExp = /((?:http|https|ssh|ftp):\/\/(?:[\w\./-]+))/gi;
   transform(value: string, []) : string {
-    return value.replace(this.pattern, function(match, $1) {
-      return '<a href="' + $1 + '">' + $1 + '</a>';
-    });
+    if (value && typeof value === 'string') {
+      return value.replace(this.pattern, function(match, $1) {
+        return '<a href="' + $1 + '">' + $1 + '</a>';
+      }); 
+    }
+    return value;
   }
 }


### PR DESCRIPTION
Only call `replace` on truthy strings.

Did I miss anything @andreasolund, or should this cover "all" bases?
